### PR TITLE
Improve handling of large numbers of vulnerabilities

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -46,7 +46,13 @@ program
       ({ stdout, stderr } = error)
     }
 
-    const results = JSON.parse(stdout)
+    let results
+    try {
+      results = JSON.parse(stdout)
+    } catch (error) {
+      console.log('Could not parse JSON output from `npm audit`')
+      process.exit(1)
+    }
     const advisories = results.advisories
     // List of IDs filtered to the ones that are marked for display
     const passThruAdvisoriesIds = Object.keys(results.advisories).filter(x => !exceptionIds.includes(parseInt(x)))

--- a/src/cli.js
+++ b/src/cli.js
@@ -39,7 +39,7 @@ program
       // (i.e., without var/let/const)
       ({ stdout, stderr } = await exec(
         'npm audit --json',
-        { cwd: projectDir, maxBuffer: 1000000 }
+        { cwd: projectDir, maxBuffer: 30 * 1048576 }
       ))
     } catch(error) {
       // See above


### PR DESCRIPTION
This pull request increases the max size that the script will read from `stdout` before truncating. This means we will run into fewer errors when parsing the output JSON for projects with a large number of dependencies and/or vulnerabilities. I have also added some very basic error handling to the `JSON.parse` call where we exit the script with code 1 if we cannot parse the JSON.